### PR TITLE
add automatic url completion 

### DIFF
--- a/components/Wysiwyg/Blocks/Text.js
+++ b/components/Wysiwyg/Blocks/Text.js
@@ -21,6 +21,12 @@ class Text extends React.Component {
     if (typeof window !== 'undefined') {
       /* eslint-disable */
       this.Editor = require('react-quill');
+
+      // include any custom quill plugins here
+      if (this.Editor) {
+        const MagicUrl = require('quill-magic-url').default;
+        this.Editor.Quill.register('modules/magicUrl', MagicUrl);
+      }
       /* eslint-enable */
     }
   }

--- a/components/Wysiwyg/constants.js
+++ b/components/Wysiwyg/constants.js
@@ -30,12 +30,7 @@ const DEFAULT_BLOCKS = {
         [{ list: 'ordered' }, { list: 'bullet' }],
         ['link']
       ],
-      magicUrl: {
-        // Regex used to check URLs during typing
-        urlRegularExpression: /((http(s?)|ftp):\/\/)?(www\.)?(\w+)(\.\w+)+/,
-        // Regex used to check URLs on paste
-        globalRegularExpression: /((http(s?)|ftp):\/\/)?(www\.)?(\w+)(\.\w+)+/g
-      }
+      magicUrl: true
     }
   },
 

--- a/components/Wysiwyg/constants.js
+++ b/components/Wysiwyg/constants.js
@@ -1,3 +1,5 @@
+
+
 // Visual Blocks
 import TextBlock from 'components/Wysiwyg/Blocks/Text';
 import ImageBlock from 'components/Wysiwyg/Blocks/Image';
@@ -27,7 +29,13 @@ const DEFAULT_BLOCKS = {
         ['bold', 'italic', 'underline'],
         [{ list: 'ordered' }, { list: 'bullet' }],
         ['link']
-      ]
+      ],
+      magicUrl: {
+        // Regex used to check URLs during typing
+        urlRegularExpression: /((http(s?)|ftp):\/\/)?(www\.)?(\w+)(\.\w+)+/,
+        // Regex used to check URLs on paste
+        globalRegularExpression: /((http(s?)|ftp):\/\/)?(www\.)?(\w+)(\.\w+)+/g
+      }
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "postcss-loader": "1.3.3",
     "postcss-middleware": "1.1.3",
     "prop-types": "^15.6.1",
+    "quill-magic-url": "^1.0.0",
     "raw-loader": "0.5.1",
     "react": "16.3.2",
     "react-dom": "16.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,6 +650,14 @@ babel-loader@7.1.2, babel-loader@^7.1.2:
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
 
+babel-loader@^7.1.4:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.5.tgz#e3ee0cd7394aa557e013b02d3e492bfd07aa6d68"
+  dependencies:
+    find-cache-dir "^1.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -6170,6 +6178,10 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+normalize-url@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.2.0.tgz#98d0948afc82829f374320f405fe9ca55a5f8567"
+
 normalize.css@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-7.0.0.tgz#abfb1dd82470674e0322b53ceb1aaf412938e4bf"
@@ -7336,6 +7348,14 @@ quill-delta@^3.6.2:
     deep-equal "^1.0.1"
     extend "^3.0.1"
     fast-diff "1.1.2"
+
+quill-magic-url@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/quill-magic-url/-/quill-magic-url-1.0.0.tgz#d4cb89cc25174598c7190a3be11804eeb65e2ef5"
+  dependencies:
+    babel-loader "^7.1.4"
+    normalize-url "^3.0.1"
+    quill-delta "^3.6.2"
 
 quill@^1.2.6:
   version "1.3.4"


### PR DESCRIPTION
automatically create links when typing one. https://github.com/visualjerk/quill-magic-url

issue reported here: https://www.pivotaltracker.com/story/show/158860330

This is an issue with the [bubble quill theme](https://github.com/quilljs/quill/issues/1380). So this is a solution for working with links in a more convenient way. 
